### PR TITLE
Resolve null argument exception

### DIFF
--- a/src/Model/AttachmentResolver.php
+++ b/src/Model/AttachmentResolver.php
@@ -62,7 +62,7 @@ class AttachmentResolver
 
     public function isValidFile($file)
     {
-        if (!strlen($file)) {
+        if (!strlen($file ?? '')) {
             return false;
         }
         return $this->file->isFile($this->getAttachmentPath($file));


### PR DESCRIPTION
in the function `isValidFile($file)`, `$file` can be `null`  which will generate an exception.